### PR TITLE
fix: k8s.gcr.io image registry has been frozen

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Bypass GFW, container registry mirrors for  kubernetes developer in China mainla
 
 ## Registry list
 
-| origin     | mirror      |
-| ---------- | ----------- |
-| docker.io  | hub.k8s.li  |
-| k8s.gcr.io | gcr.k8s.li  |
-| quay.io    | quay.k8s.li |
+| origin          | mirror      |
+| ----------      | ----------- |
+| docker.io       | hub.k8s.li  |
+| registry.k8s.io | gcr.k8s.li  |
+| quay.io         | quay.k8s.li |
 
 ## Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,15 +43,15 @@ services:
     depends_on:
       - redis
 
-  gcr-registry:
+  k8s-registry:
     image: registry:2
-    container_name: gcr-registry
+    container_name: k8s-registry
     restart: always
     volumes:
       - ./config.yml:/etc/docker/registry/config.yml
       - ./data:/var/lib/registry
     environment:
-      - REGISTRY_PROXY_REMOTEURL=https://k8s.gcr.io
+      - REGISTRY_PROXY_REMOTEURL=https://registry.k8s.io
     depends_on:
       - redis
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -52,7 +52,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_pass   http://gcr-registry:5000;
+        proxy_pass   http://k8s-registry:5000;
     }
 }
 


### PR DESCRIPTION
Refer to: https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/